### PR TITLE
fix: should use nuxthub preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "dev": "nuxi dev",
     "build": "nuxi build",
-    "preview": "nuxt preview",
+    "preview": "npx nuxthub preview",
     "db:generate": "drizzle-kit generate",
     "lint": "eslint .",
     "postinstall": "nuxt prepare"


### PR DESCRIPTION
Hi @atinux, this pr is because I encountered a problem when using `nuxthub preview` **locally**. 

If wrangler version >= 3.101.0, database migration seems OK, but the database does not work correctly afterwards. 

Is this a bug related [`nuxthub/cli`](https://github.com/nuxt-hub/cli)?